### PR TITLE
Handle STR0NNN in a generic way

### DIFF
--- a/tubesync/sync/utils.py
+++ b/tubesync/sync/utils.py
@@ -134,6 +134,21 @@ def seconds_to_timestr(seconds):
    return '{:02d}:{:02d}:{:02d}'.format(hour, minutes, seconds)
 
 
+def normalize_codec(codec_str):
+    result = str(codec_str)
+    parts = result.split('.')
+    if len(parts) > 0:
+        result = parts[0].strip()
+    else:
+        return None
+    if 'NONE' == result:
+        return None
+    if str(0) in result:
+        prefix = result.rstrip('0123456789')
+        result = prefix + str(int(result[len(prefix):]))
+    return result.upper()
+
+
 def parse_media_format(format_dict):
     '''
         This parser primarily adapts the format dict returned by youtube-dl into a
@@ -141,21 +156,9 @@ def parse_media_format(format_dict):
         any internals, update it here.
     '''
     vcodec_full = format_dict.get('vcodec', '')
-    vcodec_parts = vcodec_full.split('.')
-    if len(vcodec_parts) > 0:
-        vcodec = vcodec_parts[0].strip().upper()
-    else:
-        vcodec = None
-    if vcodec == 'NONE':
-        vcodec = None
+    vcodec = normalize_codec(vcodec_full)
     acodec_full = format_dict.get('acodec', '')
-    acodec_parts = acodec_full.split('.')
-    if len(acodec_parts) > 0:
-        acodec = acodec_parts[0].strip().upper()
-    else:
-        acodec = None
-    if acodec == 'NONE':
-        acodec = None
+    acodec = normalize_codec(acodec_full) 
     try:
         fps = int(format_dict.get('fps', 0))
     except (ValueError, TypeError):


### PR DESCRIPTION
The function should return 'VP9' for:

- vp9.1.2.3
- vp09.4.5.6

As well as other variations.
It also works for avc01 or av01, or any others that fit the pattern.