### PR TITLE
Configure isolation_level from transaction_mode

### DIFF
--- a/tubesync/tubesync/sqlite3/base.py
+++ b/tubesync/tubesync/sqlite3/base.py
@@ -25,4 +25,9 @@ class DatabaseWrapper(base.DatabaseWrapper):
                 for init_cmd in cmds:
                     cursor.execute(init_cmd.strip())
 
+    
+    def get_new_connection(self, conn_params):
+        conn_params["isolation_level"] = conn_params.pop("transaction_mode", "DEFERRED")
+        super().get_new_connection(conn_params)
+
 


### PR DESCRIPTION
TypeError: 'transaction_mode' is an invalid keyword argument for Connection()