### PR TITLE
Filter out the init_command key

### DIFF
--- a/tubesync/tubesync/sqlite3/base.py
+++ b/tubesync/tubesync/sqlite3/base.py
@@ -27,7 +27,9 @@ class DatabaseWrapper(base.DatabaseWrapper):
 
     
     def get_new_connection(self, conn_params):
-        conn_params["isolation_level"] = conn_params.pop("transaction_mode", "DEFERRED")
-        super().get_new_connection(conn_params)
+        filtered_params = conn_params.copy()
+        filtered_params["isolation_level"] = filtered_params.pop("transaction_mode", "DEFERRED")
+        _ = filtered_params.pop("init_command", None)
+        super().get_new_connection(filtered_params)
 
 


### PR DESCRIPTION
TypeError: 'init_command' is an invalid keyword argument for Connection()