### PR TITLE
Handle raise_no_formats exception

### DIFF
--- a/tubesync/sync/youtube.py
+++ b/tubesync/sync/youtube.py
@@ -83,6 +83,7 @@ def get_media_info(url):
     '''
     opts = get_yt_opts()
     opts.update({
+        'ignore_no_formats_error': False,
         'skip_download': True,
         'forcejson': True,
         'simulate': True,
@@ -93,6 +94,11 @@ def get_media_info(url):
     with yt_dlp.YoutubeDL(opts) as y:
         try:
             response = y.extract_info(url, download=False)
+        except yt_dlp.utils.ExtractorError as e:
+            if not e.expected:
+                raise e
+            log.warn(e.msg)
+            pass
         except yt_dlp.utils.DownloadError as e:
             raise YouTubeError(f'Failed to extract_info for "{url}": {e}') from e
     if not response:


### PR DESCRIPTION
Catching this and checking the message may be the best way to skip members only videos.