### PR TITLE
Update ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v4
       - name: Install Python ${{ matrix.python-version }}


### PR DESCRIPTION
Python `3.13` is not expected to work until Django `5.1` and we are currently using `3.2`, so that's not worth testing.

More info: https://code.djangoproject.com/ticket/34900