### PR TITLE
Verbose output is no longer needed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -189,7 +189,7 @@ RUN set -x && \
   apt-get -y autoclean && \
   rm -rf /var/lib/apt/lists/* && \
   rm -rf /var/cache/apt/* && \
-  rm -rfv /tmp/*
+  rm -rf /tmp/*
 
 
 # Copy app


### PR DESCRIPTION
I confirmed that the changes reduced the amount of files being removed.