### PR TITLE
Use filename_path

### DIFF
--- a/tubesync/sync/templates/sync/media-item.html
+++ b/tubesync/sync/templates/sync/media-item.html
@@ -98,7 +98,7 @@
       {% if media.downloaded %}
       <tr title="The filename the media will be downloaded as">
         <td class="hide-on-small-only">Filename</td>
-        <td><span class="hide-on-med-and-up">Filename<br></span><strong>{{ media.filepath.name }}</strong></td>
+        <td><span class="hide-on-med-and-up">Filename<br></span><strong>{{ filename_path.name }}</strong></td>
       </tr>
       <tr title="The directory the media will be downloaded to">
         <td class="hide-on-small-only">Directory</td>


### PR DESCRIPTION
It's more directly what we want here.

If `filepath` ever changed to not use `filename` the value would be incorrect, so this is the cleaner way to display this value.