### PR TITLE
Dockerfile syntax and checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,6 @@
+# syntax=docker/dockerfile:1
+# check=error=true
+
 FROM debian:bookworm-slim
 
 ARG TARGETARCH
@@ -228,7 +231,7 @@ RUN set -x && \
 COPY config/root /
 
 # Create a healthcheck
-HEALTHCHECK --interval=1m --timeout=10s CMD /app/healthcheck.py http://127.0.0.1:8080/healthcheck
+HEALTHCHECK --interval=1m --timeout=10s --start-period=3m CMD ["/app/healthcheck.py", "http://127.0.0.1:8080/healthcheck"]
 
 # ENVS and ports
 ENV PYTHONPATH="/app" PYTHONPYCACHEPREFIX="/config/cache/pycache"


### PR DESCRIPTION
- Specify the syntax be the latest stable version and that failed checks should stop the build.

```
By default, builds with failing build checks exit with a zero status code despite warnings. To make the build fail on warnings, set #check=error=true.
```

- Use the form of health checking that doesn't involve an extra shell on every check.