### PR TITLE
Cache for pipenv & apt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -99,7 +99,7 @@ RUN set -eu ; \
 \
     mkdir -v -p "/verified/${TARGETARCH}" ; \
     ln -v "${FFMPEG_PREFIX_FILE}"*-"${FFMPEG_ARCH}"-*"${FFMPEG_SUFFIX_FILE}" "/verified/${TARGETARCH}/" ; \
-    rm -rf "${DESTDIR}" ;
+    rm -rf "${DESTDIR}" ; ls -alR /*ed ;
 
 FROM alpine:${ALPINE_VERSION} AS ffmpeg-extracted
 COPY --from=ffmpeg-download /verified /verified

--- a/Dockerfile
+++ b/Dockerfile
@@ -225,7 +225,8 @@ COPY --from=s6-overlay-extracted /s6-overlay-rootfs /
 
 FROM debian:${DEBIAN_VERSION} AS cache-apt
 ARG DEBIAN_PKGS
-RUN --mount=type=cache,id=apt-cache,sharing=private,target=/cache/apt \
+RUN --mount=type=cache,id=apt-lib,sharing=locked,target=/var/lib/apt \
+    --mount=type=cache,id=apt-cache,sharing=locked,target=/var/cache/apt \
     set -eu ; \
     rm -f /etc/apt/apt.conf.d/docker-clean ; \
     DEBIAN_FRONTEND='noninteractive'; export DEBIAN_FRONTEND ; \
@@ -236,7 +237,7 @@ RUN --mount=type=cache,id=apt-cache,sharing=private,target=/cache/apt \
     mkdir -v -p "${cache_dir}" ; \
     tar -C /var/cache -cf "${cache_dir}/cache.tar" apt ; \
     tar -C /var/lib -cf "${cache_dir}/lib.tar" apt ; \
-    apt-get --assume-yes clean ; \
+    apt-get --assume-yes autoclean ; \
     file="${cache_dir}/apt.sh" ; \
     printf -- '#!/bin/sh\n\n' >| "${file}" ; \
     chmod -v a+rx "${file}" ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN set -eu ; \
 \
     mkdir -v -p "/verified/${TARGETARCH}" ; \
     ln -v "${FFMPEG_PREFIX_FILE}"*-"${FFMPEG_ARCH}"-*"${FFMPEG_SUFFIX_FILE}" "/verified/${TARGETARCH}/" ; \
-    rm -rf "${DESTDIR}" ; ls -alR /*ed ;
+    rm -rf "${DESTDIR}" ;
 
 FROM alpine:${ALPINE_VERSION} AS ffmpeg-extracted
 COPY --from=ffmpeg-download /verified /verified

--- a/Dockerfile
+++ b/Dockerfile
@@ -229,8 +229,8 @@ RUN \
     printf -- '#!/bin/sh\n\n' >| "${file}" ; \
     chmod -v a+rx "${file}" ; \
     printf -- '%s\n' >> "${file}" \
-        'tar -C /var/cache -xpf "${cache_dir}"/cache.tar ;' \
-        'tar -C /var/lib -xpf "${cache_dir}"/lib.tar ;'
+        'tar -C /var/cache -xpf '"${cache_dir}"'/cache.tar ;' \
+        'tar -C /var/lib -xpf '"${cache_dir}"'/lib.tar ;'
 
 FROM debian:${DEBIAN_VERSION} AS tubesync
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -240,6 +240,8 @@ RUN \
     printf -- '#!/bin/sh\n\n' >| "${file}" ; \
     chmod -v a+rx "${file}" ; \
     printf -- '%s\n' >> "${file}" \
+        'rm -f /etc/apt/apt.conf.d/docker-clean ;' \
+        'set -e ;' \
         'cd "$(dirname "$0")" ;' \
         'tar -C /var/cache -xpf cache.tar ;' \
         'tar -C /var/lib -xpf lib.tar ;'

--- a/Dockerfile
+++ b/Dockerfile
@@ -274,7 +274,7 @@ COPY --from=s6-overlay / /
 COPY --from=ffmpeg /usr/local/bin/ /usr/local/bin/
 
 # Reminder: the SHELL handles all variables
-RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
+RUN --mount=type=cache,id=apt-cache,readonly,target=/cache \
   set -x && \
   { test -x /cache/apt.sh && /cache/apt.sh ; } && \
   apt-get update && \
@@ -295,7 +295,7 @@ RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
   rm -rf /tmp/*
 
 # Install dependencies we keep
-RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
+RUN --mount=type=cache,id=apt-cache,readonly,target=/cache \
   set -x && \
   { test -x /cache/apt.sh && /cache/apt.sh ; } && \
   apt-get update && \
@@ -332,7 +332,7 @@ WORKDIR /app
 # Set up the app
 RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
     --mount=type=cache,id=pipenv-cache,sharing=locked,target=/cache/pipenv \
-    --mount=type=cache,id=apt-cache,readonly,from=cache-apt,source=/cache/apt,target=/cache/apt \
+    --mount=type=cache,id=apt-cache,readonly,target=/cache/apt \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   unset -v PIP_NO_CACHE_DIR ; \
   set -x && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -276,7 +276,7 @@ COPY --from=ffmpeg /usr/local/bin/ /usr/local/bin/
 # Reminder: the SHELL handles all variables
 RUN --mount=type=cache,id=apt-cache,readonly,target=/cache \
   set -x && \
-  { test -x /cache/apt.sh && /cache/apt.sh ; } && \
+  { test -x /cache/apt.sh && /cache/apt.sh || : ; } && \
   apt-get update && \
   apt-get -y --no-install-recommends install locales && \
   printf -- "en_US.UTF-8 UTF-8\n" > /etc/locale.gen && \
@@ -297,7 +297,7 @@ RUN --mount=type=cache,id=apt-cache,readonly,target=/cache \
 # Install dependencies we keep
 RUN --mount=type=cache,id=apt-cache,readonly,target=/cache \
   set -x && \
-  { test -x /cache/apt.sh && /cache/apt.sh ; } && \
+  { test -x /cache/apt.sh && /cache/apt.sh || : ; } && \
   apt-get update && \
   # Install required distro packages
   apt-get -y --no-install-recommends install \
@@ -336,7 +336,7 @@ RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   unset -v PIP_NO_CACHE_DIR ; \
   set -x && \
-  { test -x /cache/apt/apt.sh && /cache/apt/apt.sh ; } && \
+  { test -x /cache/apt/apt.sh && /cache/apt/apt.sh || : ; } && \
   apt-get update && \
   # Install required build packages
   apt-get -y --no-install-recommends install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,11 @@ ARG FFMPEG_SUFFIX_FILE=".tar.xz"
 ARG FFMPEG_CHECKSUM_ALGORITHM="sha256"
 ARG S6_CHECKSUM_ALGORITHM="sha256"
 
-ARG DEBIAN_PKGS="binutils ca-certificates curl file gcc g++ less libjpeg-dev libwebp-dev locales make nginx-light pipenv python3-dev xz-utils"
+ARG DEBIAN_PKGS="\
+    binutils build-essential ca-certificates curl file gcc g++ less \
+    libjpeg-dev libjson-perl libssl-dev libwebp-dev locales make \
+    nginx-light pipenv python3-dev python3-pip python3-setuptools xz-utils \
+    "
 
 FROM alpine:${ALPINE_VERSION} AS ffmpeg-download
 ARG FFMPEG_DATE
@@ -269,7 +273,8 @@ COPY --from=ffmpeg /usr/local/bin/ /usr/local/bin/
 # Reminder: the SHELL handles all variables
 RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
   set -x && \
-  { test -x /cache/apt.sh && /cache/apt.sh || apt-get update ; } && \
+  { test -x /cache/apt.sh && /cache/apt.sh ; } && \
+  apt-get update && \
   apt-get -y --no-install-recommends install locales && \
   printf -- "en_US.UTF-8 UTF-8\n" > /etc/locale.gen && \
   locale-gen en_US.UTF-8 && \
@@ -289,7 +294,8 @@ RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
 # Install dependencies we keep
 RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
   set -x && \
-  { test -x /cache/apt.sh && /cache/apt.sh || apt-get update ; } && \
+  { test -x /cache/apt.sh && /cache/apt.sh ; } && \
+  apt-get update && \
   # Install required distro packages
   apt-get -y --no-install-recommends install \
   libjpeg62-turbo \
@@ -327,7 +333,8 @@ RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   unset -v PIP_NO_CACHE_DIR ; \
   set -x && \
-  { test -x /cache/apt/apt.sh && /cache/apt/apt.sh || apt-get update ; } && \
+  { test -x /cache/apt/apt.sh && /cache/apt/apt.sh ; } && \
+  apt-get update && \
   # Install required build packages
   apt-get -y --no-install-recommends install \
   default-libmysqlclient-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -220,6 +220,7 @@ COPY --from=s6-overlay-extracted /s6-overlay-rootfs /
 FROM debian:${DEBIAN_VERSION} AS cache-apt
 RUN \
     set -eu ; \
+    rm -f /etc/apt/apt.conf.d/docker-clean ; \
     DEBIAN_FRONTEND="noninteractive" apt-get update ; \
     cache_dir='/cache/apt' ; \
     mkdir -v -p "${cache_dir}" ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -225,7 +225,7 @@ COPY --from=s6-overlay-extracted /s6-overlay-rootfs /
 
 FROM debian:${DEBIAN_VERSION} AS cache-apt
 ARG DEBIAN_PKGS
-RUN \
+RUN --mount=type=cache,id=apt-cache,sharing=locked,target=/cache/apt \
     set -eu ; \
     rm -f /etc/apt/apt.conf.d/docker-clean ; \
     DEBIAN_FRONTEND='noninteractive'; export DEBIAN_FRONTEND ; \
@@ -236,6 +236,7 @@ RUN \
     mkdir -v -p "${cache_dir}" ; \
     tar -C /var/cache -cf "${cache_dir}/cache.tar" apt ; \
     tar -C /var/lib -cf "${cache_dir}/lib.tar" apt ; \
+    apt-get --assume-yes clean ; \
     file="${cache_dir}/apt.sh" ; \
     printf -- '#!/bin/sh\n\n' >| "${file}" ; \
     chmod -v a+rx "${file}" ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -346,7 +346,7 @@ RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
   cp -at /tmp/ "${HOME}" && \
   PIPENV_VERBOSITY=64 HOME="/tmp/${HOME#/}" pipenv install --system --skip-lock && \
   # Clean up
-  rm /app/Pipfile && \
+  rm -f /app/Pipfile && \
   pipenv --clear && \
   apt-get -y autoremove --purge \
   default-libmysqlclient-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG FFMPEG_SUFFIX_FILE=".tar.xz"
 ARG FFMPEG_CHECKSUM_ALGORITHM="sha256"
 ARG S6_CHECKSUM_ALGORITHM="sha256"
 
-ARG DEBIAN_PKGS="binutils ca-certificates curl file gcc g++ less locales make nginx-light pipenv python3-dev xz-utils"
+ARG DEBIAN_PKGS="binutils ca-certificates curl file gcc g++ less libjpeg-dev libwebp-dev locales make nginx-light pipenv python3-dev xz-utils"
 
 FROM alpine:${ALPINE_VERSION} AS ffmpeg-download
 ARG FFMPEG_DATE

--- a/Dockerfile
+++ b/Dockerfile
@@ -245,9 +245,6 @@ COPY --from=ffmpeg /usr/local/bin/ /usr/local/bin/
 RUN --mount=type=cache,id=apt-lib-cache,sharing=locked,target=/var/lib/apt \
     --mount=type=cache,id=apt-cache-cache,sharing=locked,target=/var/cache/apt \
   set -x && \
-  # Create a 'app' user which the application will run as
-  groupadd app && \
-  useradd -M -d /app -s /bin/false -g app app && \
   # Update from the network and keep cache
   rm -f /etc/apt/apt.conf.d/docker-clean ; \
   apt-get update && \
@@ -304,6 +301,10 @@ RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   unset -v PIP_NO_CACHE_DIR ; \
   set -x && \
+  # Create a 'app' user which the application will run as
+  groupadd app && \
+  useradd -M -d /app -s /bin/false -g app app && \
+  # Update from the network and keep cache
   rm -f /etc/apt/apt.conf.d/docker-clean ; \
   apt-get update && \
   # Install required build packages

--- a/Dockerfile
+++ b/Dockerfile
@@ -389,7 +389,7 @@ RUN set -x && \
   mkdir -v -p /config/media && \
   mkdir -v -p /config/cache/pycache && \
   mkdir -v -p /downloads/audio && \
-  mkdir -v -p /downloads/video \
+  mkdir -v -p /downloads/video && \
   # Append software versions
   ffmpeg_version=$(/usr/local/bin/ffmpeg -version | awk -v 'ev=31' '1 == NR && "ffmpeg" == $1 { print $3; ev=0; } END { exit ev; }') && \
   test -n "${ffmpeg_version}" && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -274,7 +274,7 @@ COPY --from=s6-overlay / /
 COPY --from=ffmpeg /usr/local/bin/ /usr/local/bin/
 
 # Reminder: the SHELL handles all variables
-RUN --mount=type=cache,id=apt-cache,readonly,target=/cache \
+RUN --mount=type=cache,id=apt-cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
   set -x && \
   { test -x /cache/apt.sh && /cache/apt.sh || : ; } && \
   apt-get update && \
@@ -295,7 +295,7 @@ RUN --mount=type=cache,id=apt-cache,readonly,target=/cache \
   rm -rf /tmp/*
 
 # Install dependencies we keep
-RUN --mount=type=cache,id=apt-cache,readonly,target=/cache \
+RUN --mount=type=cache,id=apt-cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
   set -x && \
   { test -x /cache/apt.sh && /cache/apt.sh || : ; } && \
   apt-get update && \
@@ -332,7 +332,7 @@ WORKDIR /app
 # Set up the app
 RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
     --mount=type=cache,id=pipenv-cache,sharing=locked,target=/cache/pipenv \
-    --mount=type=cache,id=apt-cache,readonly,target=/cache/apt \
+    --mount=type=cache,id=apt-cache,readonly,from=cache-apt,source=/cache/apt,target=/cache/apt \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   unset -v PIP_NO_CACHE_DIR ; \
   set -x && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -230,15 +230,15 @@ RUN \
     ${DEBIAN_PKGS} ; \
     cache_dir='/cache/apt' ; \
     mkdir -v -p "${cache_dir}" ; \
-    tar -C /var/cache -cJf "${cache_dir}/cache.tar.xz" apt ; \
-    tar -C /var/lib -cJf "${cache_dir}/lib.tar.xz" apt ; \
+    tar -C /var/cache -cf "${cache_dir}/cache.tar" apt ; \
+    tar -C /var/lib -cf "${cache_dir}/lib.tar" apt ; \
     file="${cache_dir}/apt.sh" ; \
     printf -- '#!/bin/sh\n\n' >| "${file}" ; \
     chmod -v a+rx "${file}" ; \
     printf -- '%s\n' >> "${file}" \
         'cd "$(dirname "$0")" ;' \
-        'tar -C /var/cache -xpf cache.tar.xz ;' \
-        'tar -C /var/lib -xpf lib.tar.xz ;'
+        'tar -C /var/cache -xpf cache.tar ;' \
+        'tar -C /var/lib -xpf lib.tar ;'
 
 FROM debian:${DEBIAN_VERSION} AS tubesync
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -287,14 +287,14 @@ COPY pip.conf /etc/pip.conf
 
 # Do not include compiled byte-code
 ENV PIP_NO_COMPILE=1 \
-  PIP_NO_CACHE_DIR=1 \
   PIP_ROOT_USER_ACTION='ignore'
 
 # Switch workdir to the the app
 WORKDIR /app
 
 # Set up the app
-RUN --mount=type=cache,id=pipenv-cache,sharing=locked,target=/cache/pipenv \
+RUN --mount=type=tmpfs,target=/cache \
+    --mount=type=cache,id=pipenv-cache,sharing=locked,target=/cache/pipenv \
     --mount=type=cache,id=apt-lib-cache,sharing=locked,target=/var/lib/apt \
     --mount=type=cache,id=apt-cache-cache,sharing=locked,target=/var/cache/apt \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
@@ -322,6 +322,7 @@ RUN --mount=type=cache,id=pipenv-cache,sharing=locked,target=/cache/pipenv \
   # Install non-distro packages
   cp -at /tmp/ "${HOME}" && \
   HOME="/tmp/${HOME#/}" \
+  XDG_CACHE_HOME='/cache' \
   PIPENV_VERBOSITY=64 \
   PIPENV_CACHE_DIR='/cache/pipenv' \
     pipenv install --system --skip-lock && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ ARG DESTDIR="/downloaded"
 ARG TARGETARCH
 ADD "${FFMPEG_URL}/${FFMPEG_FILE_SUMS}" "${DESTDIR}/"
 RUN set -eu ; \
-    apk --no-cache --no-progress add cmd:aria2c cmd:awk ; \
+    apk --no-cache --no-progress add cmd:aria2c cmd:awk "cmd:${CHECKSUM_ALGORITHM}sum" ; \
 \
     aria2c_options() { \
         algorithm="${CHECKSUM_ALGORITHM%[0-9]??}" ; \
@@ -80,8 +80,6 @@ RUN set -eu ; \
       --summary-interval=0 \
       --input-file /tmp/downloads ; \
 \
-    apk --no-cache --no-progress add "cmd:${CHECKSUM_ALGORITHM}sum" ; \
-\    
     decide_expected() { \
         case "${TARGETARCH}" in \
             (amd64) printf -- '%s' "${FFMPEG_CHECKSUM_AMD64}" ;; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -229,8 +229,9 @@ RUN \
     printf -- '#!/bin/sh\n\n' >| "${file}" ; \
     chmod -v a+rx "${file}" ; \
     printf -- '%s\n' >> "${file}" \
-        'tar -C /var/cache -xpf '"${cache_dir}"'/cache.tar ;' \
-        'tar -C /var/lib -xpf '"${cache_dir}"'/lib.tar ;'
+        'cd "$(dirname "$0")" ;' \
+        'tar -C /var/cache -xpf cache.tar ;' \
+        'tar -C /var/lib -xpf lib.tar ;'
 
 FROM debian:${DEBIAN_VERSION} AS tubesync
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -298,9 +298,6 @@ RUN --mount=type=tmpfs,target=/cache \
     --mount=type=cache,id=apt-cache-cache,sharing=locked,target=/var/cache/apt \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   set -x && \
-  # Create a 'app' user which the application will run as
-  groupadd app && \
-  useradd -M -d /app -s /bin/false -g app app && \
   # Update from the network and keep cache
   rm -f /etc/apt/apt.conf.d/docker-clean && \
   apt-get update && \
@@ -318,6 +315,9 @@ RUN --mount=type=tmpfs,target=/cache \
   python3-pip \
   zlib1g-dev \
   && \
+  # Create a 'app' user which the application will run as
+  groupadd app && \
+  useradd -M -d /app -s /bin/false -g app app && \
   # Install non-distro packages
   cp -at /tmp/ "${HOME}" && \
   HOME="/tmp/${HOME#/}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -225,7 +225,7 @@ COPY --from=s6-overlay-extracted /s6-overlay-rootfs /
 
 FROM debian:${DEBIAN_VERSION} AS cache-apt
 ARG DEBIAN_PKGS
-RUN --mount=type=cache,id=apt-cache,sharing=locked,target=/cache/apt \
+RUN --mount=type=cache,id=apt-cache,sharing=private,target=/cache/apt \
     set -eu ; \
     rm -f /etc/apt/apt.conf.d/docker-clean ; \
     DEBIAN_FRONTEND='noninteractive'; export DEBIAN_FRONTEND ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -346,7 +346,6 @@ RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
   cp -at /tmp/ "${HOME}" && \
   PIPENV_VERBOSITY=64 HOME="/tmp/${HOME#/}" pipenv install --system --skip-lock && \
   # Clean up
-  rm -f /app/Pipfile && \
   pipenv --clear && \
   apt-get -y autoremove --purge \
   default-libmysqlclient-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -294,12 +294,10 @@ ENV PIP_NO_COMPILE=1 \
 WORKDIR /app
 
 # Set up the app
-RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
-    --mount=type=cache,id=pipenv-cache,sharing=locked,target=/cache/pipenv \
+RUN --mount=type=cache,id=pipenv-cache,sharing=locked,target=/cache/pipenv \
     --mount=type=cache,id=apt-lib-cache,sharing=locked,target=/var/lib/apt \
     --mount=type=cache,id=apt-cache-cache,sharing=locked,target=/var/cache/apt \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
-  unset -v PIP_NO_CACHE_DIR ; \
   set -x && \
   # Create a 'app' user which the application will run as
   groupadd app && \
@@ -325,7 +323,6 @@ RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
   cp -at /tmp/ "${HOME}" && \
   HOME="/tmp/${HOME#/}" \
   PIPENV_VERBOSITY=64 \
-  PIP_CACHE_DIR='/cache/pip' \
   PIPENV_CACHE_DIR='/cache/pipenv' \
     pipenv install --system --skip-lock && \
   # Clean up

--- a/Dockerfile
+++ b/Dockerfile
@@ -275,7 +275,7 @@ COPY --from=s6-overlay / /
 COPY --from=ffmpeg /usr/local/bin/ /usr/local/bin/
 
 # Reminder: the SHELL handles all variables
-RUN --mount=type=cache,id=apt-cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
+RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
   set -x && \
   { test -x /cache/apt.sh && /cache/apt.sh || : ; } && \
   apt-get update && \
@@ -296,7 +296,7 @@ RUN --mount=type=cache,id=apt-cache,readonly,from=cache-apt,source=/cache/apt,ta
   rm -rf /tmp/*
 
 # Install dependencies we keep
-RUN --mount=type=cache,id=apt-cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
+RUN --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache \
   set -x && \
   { test -x /cache/apt.sh && /cache/apt.sh || : ; } && \
   apt-get update && \
@@ -333,7 +333,7 @@ WORKDIR /app
 # Set up the app
 RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
     --mount=type=cache,id=pipenv-cache,sharing=locked,target=/cache/pipenv \
-    --mount=type=cache,id=apt-cache,readonly,from=cache-apt,source=/cache/apt,target=/cache/apt \
+    --mount=type=cache,readonly,from=cache-apt,source=/cache/apt,target=/cache/apt \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   unset -v PIP_NO_CACHE_DIR ; \
   set -x && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ARG FFMPEG_SUFFIX_FILE=".tar.xz"
 ARG FFMPEG_CHECKSUM_ALGORITHM="sha256"
 ARG S6_CHECKSUM_ALGORITHM="sha256"
 
-ARG DEBIAN_PKGS="bin-utils ca-certificates curl file gcc g++ less locales make nginx-light pipenv python3-dev xz-utils"
+ARG DEBIAN_PKGS="binutils ca-certificates curl file gcc g++ less locales make nginx-light pipenv python3-dev xz-utils"
 
 FROM alpine:${ALPINE_VERSION} AS ffmpeg-download
 ARG FFMPEG_DATE
@@ -224,14 +224,14 @@ ARG DEBIAN_PKGS
 RUN \
     set -eu ; \
     rm -f /etc/apt/apt.conf.d/docker-clean ; \
-    DEBIAN_FRONTEND="noninteractive"; export DEBIAN_FRONTEND ; \
-    apt-get --quiet update ; \
-    apt-get --quiet --assume-yes install --download-only --no-install-recommends \
+    DEBIAN_FRONTEND='noninteractive'; export DEBIAN_FRONTEND ; \
+    apt-get update && \
+    apt-get --assume-yes install --download-only --no-install-recommends \
     ${DEBIAN_PKGS} ; \
     cache_dir='/cache/apt' ; \
     mkdir -v -p "${cache_dir}" ; \
-    tar -C /var/cache -cJf "${cache_dir}"/cache.tar.xz apt ; \
-    tar -C /var/lib -cJf "${cache_dir}"/lib.tar.xz apt ; \
+    tar -C /var/cache -cJf "${cache_dir}/cache.tar.xz" apt ; \
+    tar -C /var/lib -cJf "${cache_dir}/lib.tar.xz" apt ; \
     file="${cache_dir}/apt.sh" ; \
     printf -- '#!/bin/sh\n\n' >| "${file}" ; \
     chmod -v a+rx "${file}" ; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -246,7 +246,7 @@ RUN --mount=type=cache,id=apt-lib-cache,sharing=locked,target=/var/lib/apt \
     --mount=type=cache,id=apt-cache-cache,sharing=locked,target=/var/cache/apt \
   set -x && \
   # Update from the network and keep cache
-  rm -f /etc/apt/apt.conf.d/docker-clean ; \
+  rm -f /etc/apt/apt.conf.d/docker-clean && \
   apt-get update && \
   # Install locales
   apt-get -y --no-install-recommends install locales && \
@@ -305,7 +305,7 @@ RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
   groupadd app && \
   useradd -M -d /app -s /bin/false -g app app && \
   # Update from the network and keep cache
-  rm -f /etc/apt/apt.conf.d/docker-clean ; \
+  rm -f /etc/apt/apt.conf.d/docker-clean && \
   apt-get update && \
   # Install required build packages
   apt-get -y --no-install-recommends install \

--- a/Dockerfile
+++ b/Dockerfile
@@ -322,7 +322,6 @@ RUN --mount=type=tmpfs,target=/cache \
   cp -at /tmp/ "${HOME}" && \
   HOME="/tmp/${HOME#/}" \
   XDG_CACHE_HOME='/cache' \
-  # PIPENV_CACHE_DIR='/cache/pipenv'
   PIPENV_VERBOSITY=64 \
     pipenv install --system --skip-lock && \
   # Clean up

--- a/Dockerfile
+++ b/Dockerfile
@@ -327,7 +327,7 @@ RUN --mount=type=cache,id=pip-cache,sharing=locked,target=/cache/pip \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   unset -v PIP_NO_CACHE_DIR ; \
   set -x && \
-  { test -x /cache/apt.sh && /cache/apt.sh || apt-get update ; } && \
+  { test -x /cache/apt/apt.sh && /cache/apt/apt.sh || apt-get update ; } && \
   # Install required build packages
   apt-get -y --no-install-recommends install \
   default-libmysqlclient-dev \


### PR DESCRIPTION
- Consolidate apk & apt commands
- Consolidate ENV layers
- Consolidate RUN layers
- Remove unused variables
- Remove packages that are no longer needed
- Bind mount /app/Pipfile

`/cache` is now a `tmpfs` mount that has a `cache` mount on top for `pipenv` to use.

`apt` has `cache` mounts in the standard places:
- /var/lib/apt
- /var/cache/apt
