### PR TITLE
Fallback to run_whl

### DIFF
--- a/tubesync/upgrade_yt-dlp.sh
+++ b/tubesync/upgrade_yt-dlp.sh
@@ -5,12 +5,13 @@ pip3() {
 
     # pipenv
     pip_runner='/usr/lib/python3/dist-packages/pipenv/patched/pip/__pip-runner__.py'
+    test -s "${pip_runner}" || pip_runner=''
 
     # python3-pip-whl
     pip_whl="$(ls -1r /usr/share/python-wheels/pip-*-py3-none-any.whl | head -n 1)"
     run_whl="${pip_whl}/pip"
 
-    python3 "${pip_runner}" "$@"
+    python3 "${pip_runner:-"${run_whl}"}" "$@"
 }
 
 pip3 install --upgrade --break-system-packages yt-dlp


### PR DESCRIPTION
Prefer `pip_runner` but try the `pip` wheel too, if it's missing.