### PR TITLE
Put os.path.basename() back

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1308,7 +1308,7 @@ class Media(models.Model):
             filename = str(mf_path.relative_to(self.source.directory_path))
         else:
             filename = self.filename
-        prefix, ext = os.path.splitext(filename)
+        prefix, ext = os.path.splitext(os.path.basename(filename))
         return prefix
 
     @property


### PR DESCRIPTION
Without this, the subdirectory from `media_format` is doubled.