### PR TITLE
`python3 -B` is well-behaved

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -298,7 +298,7 @@ RUN --mount=type=tmpfs,target=/cache \
     --mount=type=bind,source=Pipfile,target=/app/Pipfile \
   set -x && \
   # Remove __pycache__ directories from image
-  PYTHONPYCACHEPREFIX=/tmp/pycache && \
+  PYTHONPYCACHEPREFIX=/cache/pycache && \
   export PYTHONPYCACHEPREFIX && \
   # Update from the network and keep cache
   rm -f /etc/apt/apt.conf.d/docker-clean && \
@@ -352,14 +352,9 @@ COPY tubesync/tubesync/local_settings.py.container /app/tubesync/local_settings.
 RUN set -x && \
   # Make absolutely sure we didn't accidentally bundle a SQLite dev database
   rm -rf /app/db.sqlite3 && \
-  # Remove __pycache__ directories from image
-  PYTHONPYCACHEPREFIX=/tmp/pycache && \
-  export PYTHONPYCACHEPREFIX && \
   # Run any required app commands
   /usr/bin/python3 -B /app/manage.py compilescss && \
   /usr/bin/python3 -B /app/manage.py collectstatic --no-input --link && \
-  # Clean up
-  rm -v -rf /tmp/* && \
   # Create config, downloads and run dirs
   mkdir -v -p /run/app && \
   mkdir -v -p /config/media && \


### PR DESCRIPTION
Use the `tmpfs` mount on `/cache` instead of `/tmp` to make this faster.