### PR TITLE
Revert "Use a work for lower in the tree"

### DIFF
--- a/tubesync/sync/signals.py
+++ b/tubesync/sync/signals.py
@@ -41,7 +41,7 @@ def source_pre_save(sender, instance, **kwargs):
         # the names in the relative path are also in the absolute path
         parents_count = len(ad_parents_set.intersection(rd_parents_set))
         work_directory = existing_dirpath
-        for _count in range(parents_count, 1, -1):
+        for _count in range(parents_count, 0, -1):
             work_directory = work_directory.parent
         with TemporaryDirectory(suffix=('.'+new_dirpath.name), prefix='.tmp.', dir=work_directory) as tmp_dir:
             tmp_dirpath = Path(tmp_dir)


### PR DESCRIPTION
This reverts commit 9d9cc82cc109ab5b272a3a46aba749bd8267d0d7.

That was a mistake.