### PR TITLE
Set `Media.skip` to `False`

### DIFF
--- a/tubesync/sync/models.py
+++ b/tubesync/sync/models.py
@@ -1537,7 +1537,8 @@ class Media(models.Model):
 
                     # update the media_file in the db
                     self.media_file.name = str(new_video_path.relative_to(self.media_file.storage.location))
-                    self.save()
+                    self.skip = False
+                    self.save(update_fields=('media_file', 'skip'))
                     log.info(f'Updated "media_file" in the database for: {self!s}')
 
                     (new_prefix_path, new_stem) = directory_and_stem(new_video_path)


### PR DESCRIPTION
This handles a bad interaction between files that were deleted by the user externally and need to be skipped and files that were temporarily indistinguishable from that case.

The source directory changing invalidates the absolute paths, but those should be corrected later. Leaving skip set causes display problems.