### PR TITLE
Do not uninstall `python3-virtualenv`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -313,7 +313,6 @@ RUN --mount=type=tmpfs,target=/cache \
   postgresql-common \
   python3-dev \
   python3-pip \
-  python3-virtualenv \
   zlib1g-dev \
   && \
   # Create a 'app' user which the application will run as
@@ -360,7 +359,6 @@ RUN --mount=type=tmpfs,target=/cache \
   postgresql-common \
   python3-dev \
   python3-pip \
-  python3-virtualenv \
   zlib1g-dev \
   && \
   apt-get -y autopurge && \


### PR DESCRIPTION
It's from `pipenv` which we want to keep.