### PR TITLE
Fix `virtualenv` flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -332,7 +332,7 @@ RUN --mount=type=tmpfs,target=/cache \
     HOME="${cache_path}/.home-directories/${HOME#/}" ; \
   } && \
   # install magic-wormhole
-  ( virtualenv --download --upgrade-embed-wheels "${wormhole_venv}" && \
+  ( virtualenv --download "${wormhole_venv}" && \
     . "${wormhole_venv}/bin/activate" && \
     pip install magic-wormhole ; \
   ) && \


### PR DESCRIPTION
In 1ed56ee0b8053f57035871c0930bda9846f42540, the addition of `--upgrade-embed-wheels` causes `virtualenv` to not create the directory.

Using `--download` is enough to install the latest version of `pip` during creation.